### PR TITLE
RPM .spec cleanup

### DIFF
--- a/package/libyui-rest-api.changes
+++ b/package/libyui-rest-api.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 23 13:44:46 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Spec file cleanup, use %cmake macros
+
+-------------------------------------------------------------------
 Thu Dec 20 09:57:16 UTC 2018 - Rodion Iafarov <riafarov@suse.com>
 
 - Initial commit (bsc#1132247)

--- a/package/libyui-rest-api.spec
+++ b/package/libyui-rest-api.spec
@@ -20,10 +20,6 @@
 %define bin_name %{name}%{so_version}
 %define libyui_devel_version libyui-devel >= 3.5.0
 
-# optionally build with code coverage reporting,
-# this uses debug build, do not use in production!
-%bcond_with coverage
-
 Name:           libyui-rest-api
 Version:        0.1.0
 Release:        0
@@ -55,11 +51,6 @@ BuildRequires:  libboost_headers-devel
 BuildRequires:  libboost_test-devel
 %else
 BuildRequires:  boost-devel
-%endif
-%if %{with coverage}
-# normally the coverage feature should not be used out of CI
-# but to be on the safe side...
-BuildRequires:  lcov
 %endif
 
 %description

--- a/package/libyui-rest-api.spec
+++ b/package/libyui-rest-api.spec
@@ -19,9 +19,11 @@
 %define so_version 10
 %define bin_name %{name}%{so_version}
 %define libyui_devel_version libyui-devel >= 3.5.0
+
 # optionally build with code coverage reporting,
 # this uses debug build, do not use in production!
 %bcond_with coverage
+
 Name:           libyui-rest-api
 Version:        0.1.0
 Release:        0
@@ -30,6 +32,7 @@ License:        LGPL-2.1-only OR LGPL-3.0-only
 Group:          System/Libraries
 URL:            http://github.com/libyui/libyui-rest-api
 Source:         %{name}-%{version}.tar.bz2
+
 BuildRequires:  %{libyui_devel_version}
 BuildRequires:  cmake >= 2.8
 # Qt UI specific
@@ -110,33 +113,24 @@ export CXXFLAGS="%{optflags} -DNDEBUG"
 
 ./bootstrap.sh %{_prefix}
 
-mkdir build
-cd build
-
-%if %{?_with_debug:1}%{!?_with_debug:0}
-# FIXME: you should use %%cmake macros
-cmake .. \
-        -DYPREFIX=%{_prefix} \
+# NOTE: %%cmake changes the CWD to "build" which is later expected by
+# %%cmake_build, be careful when running additional commands later...
+%cmake  -DYPREFIX=%{_prefix} \
         -DDOC_DIR=%{_docdir} \
         -DLIB_DIR=%{_lib} \
+%if %{?_with_debug:1}%{!?_with_debug:0}
         -DCMAKE_BUILD_TYPE=RELWITHDEBINFO
 %else
-# FIXME: you should use %%cmake macros
-cmake .. \
-        -DYPREFIX=%{_prefix} \
-        -DDOC_DIR=%{_docdir} \
-        -DLIB_DIR=%{_lib} \
         -DCMAKE_BUILD_TYPE=RELEASE
 %endif
 
-make %{?_smp_mflags}
+%cmake_build
 
 %install
-cd build
-%make_install
+%cmake_install
 install -m0755 -d %{buildroot}/%{_docdir}/%{bin_name}/
 install -m0755 -d %{buildroot}/%{_libdir}/yui
-install -m0644 ../COPYING* %{buildroot}/%{_docdir}/%{bin_name}/
+install -m0644 COPYING* %{buildroot}/%{_docdir}/%{bin_name}/
 
 %post -n %{bin_name} -p /sbin/ldconfig
 %postun -n %{bin_name} -p /sbin/ldconfig


### PR DESCRIPTION
- The original [SR#695449](https://build.opensuse.org/request/show/695449) was reject because of the old style `.spec` file
- **Please review each commit separately**
- The first commit contains just the changes done by running `/usr/lib/obs/service/clean_spec_file --outdir .`, i.e. no manual changes
- Then I manually switched to the `%cmake` RPM macros
- And removed the not used code coverage build option, there are no unit tests here (it was copied from the base `libyui` package used as a template, it does not make any sense here)
- Tested manually by running `osc build` locally (ah, I should add the Travis support here as well...)
