### PR TITLE
Add support for more widgets and improve activation

### DIFF
--- a/API_v1.md
+++ b/API_v1.md
@@ -1,19 +1,46 @@
+## Table of Contents
+* [LibYUI REST API v1](#libyui-rest-api-v1)
+    * [API Version](#api-version)
+        * [Description](#description)
+        * [Response](#response)
+        * [Examples](#examples)
+    * [Application Data](#application-data)
+        * [Description](#description)
+        * [Response](#response)
+        * [Examples](#examples)
+    * [Dump Whole Dialog](#dump-whole-dialog)
+        * [Description](#description)
+        * [Response](#response)
+        * [Examples](#examples)
+    * [Read Only Specific Widgets](#read-only-specific-widgets)
+        * [Description](#description)
+        * [Parameters](#parameters)
+        * [Response](#response)
+        * [Examples](#examples)
+    * [Change Widgets, Do an Action](#change-widgets-do-an-action)
+        * [Description](#description)
+        * [Parameters](#parameters)
+        * [Response](#response)
+        * [Examples](#examples)
+
 # LibYUI REST API v1
 
-This is the specification of the version 1 of the API.
+This is the specification of the version `1` of the API.
+Documentation refence is shown when accessing root url:
+```
+curl http://localhost:9999/
+```
 
-## API Documentation
-
-### API Version
+## API Version
 
 Request: `GET /version`
 
-#### Description
+### Description
 
 Get the application and UI generic properties like text or graphical mode,
 dialog size, screen size and supported UI features.
 
-#### Response
+### Response
 
 JSON format
 
@@ -26,47 +53,47 @@ JSON format
 The `api_version` value defines the version of the API. It is used in the URL
 as the path prefix.
 
-##### Examples
+### Examples
 
 ```
 curl http://localhost:9999/version
 ```
 ---
 
-### Application Data
+## Application Data
 
 Request: `GET /v1/application`
 
-#### Description
+### Description
 
 Get the application and UI generic properties like text or graphical mode,
 dialog size, screen size and supported UI features.
 
-#### Response
+### Response
 
 JSON format
 
-##### Examples
+### Examples
 
 ```
 curl http://localhost:9999/v1/application
 ```
 ---
 
-### Dump Whole Dialog
- 
+## Dump Whole Dialog
+
  Request: `GET /v1/dialog`
 
-#### Description
+### Description
 
 Get the complete dialog structure in the JSON format. The result contains
 a nested structure exactly following the structure of the current dialog.
 
-#### Response
+### Response
 
 JSON format
 
-##### Examples
+### Examples
 
 ```
 curl http://localhost:9999/v1/dialog
@@ -74,16 +101,16 @@ curl http://localhost:9999/v1/dialog
 
 ---
 
-### Read Only Specific Widgets
+## Read Only Specific Widgets
 
 Request: `GET /v1/widgets`
 
-#### Description
+### Description
 
 Return only the selected widgets (in JSON format). The result is a flat list
 (no nested structures).
 
-#### Parameters
+### Parameters
 
 Filter widgets:
 
@@ -92,29 +119,35 @@ Filter widgets:
 - **label** - widget label as currently displayed (i.e. translated!)
 - **type** - the widget type
 
-#### Response
+Any combination of the filters are also allowed. This is extremely helpful
+when multiple widgets have same id or label. Nevertheless, it's recommended
+to use unique ids in the application in order to simplify testing.
+
+### Response
 
 JSON format
 
-#### Examples
+### Examples
 
 ```
 curl 'http://localhost:9999/v1/widgets?label=Next
 curl 'http://localhost:9999/v1/widgets?id=next
 curl 'http://localhost:9999/v1/widgets?type=YCheckBox
+curl 'http://localhost:9999/v1/widgets?type=YPushButton&label=ok
+curl 'http://localhost:9999/v1/widgets?type=YPushButton&id=next
 ```
 
 ---
 
-### Change Widgets, Do an Action</h3>
+## Change Widgets, Do an Action
 
 Request: `POST /v1/widgets`
 
-#### Description
+### Description
 
 Do an action with specified widgets.
 
-#### Parameters
+### Parameters
 
 Filter the widgets, one of:
 
@@ -123,39 +156,49 @@ Filter the widgets, one of:
 - **label** - widget label as currently displayed (i.e. translated!)
 - **type** - type of the widget
 
+Same as for reading, combinations of the filters are also allowed.
+
 Then specify the action:
 
 - **action** - the action to do
 - **value** (optional) - new value or a parameter of the action
-- **column** (optional) - column id when selecting item in the table
-
+- **column** (optional) - integer, column number when selecting item in the table
+- **row** (optional) - integer, row number when selecting item in the table
 Supported actions:
 
 - **press** - to press the button
 - **check** | **uncheck**  | **toggle** - check, uncheck or toggle checkbox
 - **enter_text** - set text in the field, the text is passed in the
   *value* parameter
-- **switch_radio** - activate radio button
 - **select** - select value in the combobox, row in the table or node in the
-  tree, requires *value*parameter
+  tree, item in button menu requires *value* parameter
   - In case of table: select row in the table with given value. If
         *column* parameter is not provided, the first column will be used.  
   - In case of tree: select node in the tree. Use `|` as a delimiter for
-        the child nodes.
-
-#### Response
+        the child nodes. For example: `root|subnode|subsubnode`.
+  - In case of button menu: to select item, use `|` as a delimiter for the
+  sub-menus. For example: 'File|Save as|PDF'
+### Response
 
 JSON format
 
-#### Examples
+### Examples
 
 ```shell
 # press the "next" button
 curl -X POST 'http://localhost:9999/v1/widgets?id=next&action=press'
+# press the "next" button, filter by type and id
+curl -X POST 'http://localhost:9999/v1/widgets?type=YPushButtonid=next&action=press'
 # set value "test" for the InputField with label "Description"
 curl -X POST 'http://localhost:9999/v1/widgets?label=Description&action=enter_text&value=test'
+# select first row (counting from zero) in table with id "names"
+curl -X POST 'http://localhost:9999/v1/widgets?id=names&action=select&row=1'
 # select row with "test" cell value in the 2-nd column (counting from zero) in table with id "names"
 curl -X POST 'http://localhost:9999/v1/widgets?id=names&action=select&value=test&column=2'
 # select tree item with in tree with id "files"
 curl -X POST 'http://localhost:9999/v1/widgets?id=files&action=select&value=root|subnode|subnode'
+# press url (<a href=\"firewall\">(enable)</a>) in richtext
+curl -X POST 'http://localhost:9999/v1/widgets?type=YRichText&action=select&value=firewall'
+# select menu item with label "Image" in parent menu item with label Document in button menu
+curl -X POST 'http://localhost:9999/v1/widgets?type=YMenuButton&action=select&value=Document|Image'
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
     * [Usage](#usage)
         * [Remote Access](#remote-access)
         * [User Authentication](#user-authentication)
+        * [Reuse of the socket](#reuse-of-the-socket)
     * [Contributing](#contributing)
     * [Building](#building)
     * [Testing](#testing)
@@ -26,7 +27,10 @@ the additional bindings for the specific UI frontends
 ((libyui-ncurses-rest-api)[https://github.com/libyui/libyui-ncurses-rest-api]
 or (libyui-qt-rest-api)[https://github.com/libyui/libyui-ncurses-rest-api]).
 
-### Features
+Please, find detailed API v1 description
+[here](https://github.com/libyui/libyui-rest-api/blob/master/API_v1.md).
+
+## Features
 
 - Optional plugins which extend the standard libyui library
   - Less dependencies
@@ -44,7 +48,7 @@ or (libyui-qt-rest-api)[https://github.com/libyui/libyui-ncurses-rest-api]).
   address is based on the MAC address, you can easily get the IPv6 address for
   your testing machine)
 
-### TODO
+## TODO
 
 - [ ] Properties of some widgets are still missing
 - [ ] Allow sending more user actions
@@ -53,11 +57,15 @@ or (libyui-qt-rest-api)[https://github.com/libyui/libyui-ncurses-rest-api]).
     like passwords)
 - [ ] Allow connection via Unix domain sockets
 
-### Usage
+## Usage
 
-To start the application with rest API enabled, use the following commands:
-* `xdg-su -c 'YUI_HTTP_PORT=9999 yast2 host'` for Qt
-* `sudo YUI_HTTP_PORT=9999 yast2 host` for ncurses.
+Many YaST modules require root privileges to run, the easiest way to start
+the application with rest API enabled, is using the following commands:
+* `su -c /bin/sh -c 'YUI_HTTP_PORT=9999 yast2 host --qt'` for Qt
+* `su -c /bin/sh -c 'YUI_HTTP_PORT=9999 yast2 host --ncurses'` for ncurses.
+
+In case no super user privileges are required, command can be executed without
+`su` wrapper.
 
 After that, you can get the documentation how to interact with the UI by accessing
 http://localhost:9999 (or http://ipv6-localhost:9999 via IPv6).
@@ -102,18 +110,6 @@ For example:
 ```
 YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --qt
 ```
-
-## Contributing
-
-1. Fork it
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
-5. Create new Pull Request
-
-Please, keep coding style consistent, in case of doubts, please, refer to
-[CppCoreGuidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines).
-
 ## Building
 
 In order to build project locally one can use `make`:
@@ -146,7 +142,7 @@ For instance, to run `Table5.rb`, you can use following command:
 YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --ncurses
 ```
 
-To run qt version of the app, simply replace `ncurses` parameter with `qt` as
+To run Qt version of the app, simply replace `ncurses` parameter with `qt` as
 follows:
 ```
 YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --qt
@@ -155,6 +151,17 @@ YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --qt
 After that server should be available on the provided port and http request can
 be sent to it.
 
-# License
+## Contributing
+
+1. Fork it
+2. Create your feature branch (git checkout -b my-new-feature)
+3. Commit your changes (git commit -am 'Add some feature')
+4. Push to the branch (git push origin my-new-feature)
+5. Create new Pull Request
+
+Please, keep coding style consistent, in case of doubts, please, refer to
+[CppCoreGuidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines).
+
+## License
 This package is licensed under
 [LGPL-2.1](http://www.gnu.org/licenses/lgpl-2.1.html).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## Table of Contents
+* [libyui-rest-api](#libyui-rest-api)
+    * [Features](#features)
+    * [TODO](#todo)
+    * [Usage](#usage)
+        * [Remote Access](#remote-access)
+        * [User Authentication](#user-authentication)
+    * [Contributing](#contributing)
+    * [Building](#building)
+    * [Testing](#testing)
+* [License](#license)
+
 # libyui-rest-api
 
 Libyui UI REST API framework for integration testing.
@@ -76,90 +88,73 @@ in clear text without any encryption (only converted to the Base64 encoding).
 That means anybody on the way could read the user name and the password
 ([MITM attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack)).
 
-<!-- The following text is a copy from the ./src/YHttpRootHandler.cc file -->
+### Reuse of the socket
 
----
-<h1>LibYUI Embedded Webserver</h1>
-<p>This webserver provides a REST API for the LibYUI application.</p>
-<p>It can be used for testing and controlling the application in automated tests.</p> <br>
-<h2>Short Documentation</h2>
-<h3>Application</h3>
-<p>Request: <pre>GET /application</pre></p>
-<h4>Description</h4>
-<p>Get the application and UI generic properties like text or graphical mode, dialog size, screen size and supported UI featues.</p>
-<h4>Response</h4>
-<p>JSON format</p>
-<h4>Examples</h4>
-<p>
-    <pre>curl http://localhost:9999/application</pre>
-</p>
-<hr>
-<h3>Dump Whole Dialog</h3>
- <p>Request: <pre>GET /dialog</pre></p>
-<h4>Description</h4>
-<p>Get the complete dialog structure in the JSON format. The result contains a nested structure exactly following the structure of the current dialog.</p>
-<h4>Response</h4>
-<p>JSON format</p>
-<h4>Examples</h4>
-<p>
-    <pre>curl http://localhost:9999/dialog</pre>
-</p>
-<hr>
-<h3>Read Specific Widgets</h3>
-<p>Request: <pre>GET /widgets</pre></p>
-<h4>Description</h4>
-<p>Return only the selected widgets (in JSON format). The result is a flat list (no nested structures).</p>
-<h4>Parameters</h4>
-<p>Filter widgets: <ul>
-        <li><b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
-        <li><b>label</b> - widget label as currently displayed (i.e. translated!) </li>
-        <li><b>type</b> - widget type</li>
-    </ul>
-</p>
-<h4>Response</h4>
-<p>JSON format</p>
-<h4>Examples</h4>
-<p>
-    <pre>curl 'http://localhost:9999/widgets?id=next'</pre>
-    <pre>curl 'http://localhost:9999/widgets?label=Next'</pre>
-    <pre>curl 'http://localhost:9999/widgets?type=YCheckBox'</pre>
-</p>
-<hr>
-<h3>Change Widgets, Do an Action</h3>
-<p>Request: POST /widgets</p>
-<h4>Description</h4>
-<p>Do an action with specified widgets.</p>
-<h4>Parameters</h4>
-<p>Filter the widgets, one of: <ul>
-        <li><b>id</b> - widget ID serialized as string, might include special characters like backtick (\`)</li>
-        <li><b>label</b> - widget label as currently displayed (i.e. translated!) </li>
-        <li><b>type</b> - widget type</li>
-    </ul> Then specify the action: <ul>
-        <li><b>action</b> - action to do</li>
-        <li><b>value</b> (optional) - new value or a parameter of the action</li>
-        <li><b>column</b> (optional) - column id when selecting item in the table</li>
-    </ul>
-</p> Supported actions: <ul>
-    <li><b>press</b> - to press the button</li>
-    <li><b>check</b>|<b>uncheck</b>|<b>toggle</b> - check, uncheck or toggle checkbox</li>
-    <li><b>enter_text</b> - set text in the field, requires <b>value</b> parameter</li>
-    <li><b>switch_radio</b> - activate radio button</li>
-    <li><b>select</b> - select value in the combobox, row in the table or node in the tree, requires <b>value</b> parameter<br />
-        In case of table: select row in the table with given value. If <b>column</b> parameters is not provided, first column will be used. <br />
-        In case of tree: select node in the tree. Use <b>'|'</b> as delimiter for child nodes.</li>
+By default server side has `MHD_OPTION_LISTENING_ADDRESS_REUSE` set `0`,
+so port reuse by other processes is NOT allowed for security reasons.
+In case of quick restart of the app on the same port, it might be still binded
+and `Failed to bind to port XXXX: Address already in use` error is thrown.
+Most of the systems have timeout of 60 second before port can be reused,
+run `sysctl net.ipv4.tcp_fin_timeout` to check the value on the system.
 
-</ul>
-</p>
-<h4>Response</h4>
-<p>JSON format</p>
-<h4>Examples</h4>
-<p>
-    <pre>  # press the "next" button
-curl -X POST 'http://localhost:9999/widgets?id=next&action=press'</pre>
-    <pre>  # set value "test" for the InputField with label "Description"
-curl -X POST 'http://localhost:9999/widgets?label=Description&action=enter_text&value=test'</pre>
-    <pre>  # select row with "test" cell value in the 2-nd column (counting from zero) in table with id "names"
-curl -X POST 'http://localhost:9999/widgets?id=names&action=select&value=test&column=2'</pre>
-    <pre>  # select tree item with in tree with id "files"
-curl -X POST 'http://localhost:9999/widgets?id=files&action=select&value=root|subnode|subnode'</pre>
-</p>
+In order to allow reusing socket by other processes, set `YUI_REUSE_PORT` to `1`.
+For example:
+```
+YUI_REUSE_PORT=1 YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --qt
+```
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (git checkout -b my-new-feature)
+3. Commit your changes (git commit -am 'Add some feature')
+4. Push to the branch (git push origin my-new-feature)
+5. Create new Pull Request
+
+Please, keep coding style consistent, in case of doubts, please, refer to
+[CppCoreGuidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines).
+
+## Building
+
+In order to build project locally one can use `make`:
+* `make -f Makefile.cvs`
+* `make -C build/ install`
+
+Recommended way is to use `rake`, please refer to
+[libyui Building section](https://github.com/libyui/libyui#building).
+
+Also, see [yast-rake](https://github.com/yast/yast-rake) documentation for
+useful tasks, like `rake version:bump`.
+One can run `rake --tasks` locally to see all available tasks.
+
+## Testing
+
+In order to test changes, one can use yast modules in her system.
+As an alternative, examples from `https://github.com/yast/yast-ycp-ui-bindings`
+project can be used.
+
+For running those examples `yast2-core` package has to be preinstalled.
+
+After `yast-ycp-ui-bindings` project is checked out or `yast2-ycp-ui-bindings-devel`
+package is installed, navigate to the directory with examples. In case of
+`yast2-ycp-ui-bindings` package, this is normally
+`/usr/share/doc/packages/yast2-ycp-ui-bindings/`, otherwise simply open directory
+with cloned github repo.
+
+For instance, to run `Table5.rb`, you can use following command:
+```
+YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --ncurses
+```
+
+To run qt version of the app, simply replace `ncurses` parameter with `qt` as
+follows:
+```
+YUI_HTTP_PORT=9999 /sbin/yast2 examples/Table5.rb --qt
+```
+
+After that server should be available on the provided port and http request can
+be sent to it.
+
+# License
+This package is licensed under
+[LGPL-2.1](http://www.gnu.org/licenses/lgpl-2.1.html).

--- a/package/libyui-rest-api.changes
+++ b/package/libyui-rest-api.changes
@@ -1,13 +1,15 @@
 -------------------------------------------------------------------
 Mon Jun  8 14:37:04 UTC 2020 - Rodion Iafarov <riafarov@suse.com>
 
-- Add support for YDateField and YTimeField (bsc#1139747)
-- Trigger update on YCombobox, YSelectionBox, YInputField, YMultiSelectionBox
+- Trigger update on YCombobox, YSelectionBox, YInputField,
+  YMultiSelectionBox (bsc#1139747)
+- Add support for YDateField and YTimeField
 - Allow setting text in editable YComboBox
 - Allow selecting row in the table by row id
 - Return json format consistently
-- Add support for YDateField and YTimeField
-- Add support for YCheckBoxFrame
+- Add support for YCheckBoxFrame widget
+- Allow reusing port if YUI_REUSE_PORT=1
+- Add json serialization for YBarGraph
 - 0.5.0
 
 -------------------------------------------------------------------

--- a/package/libyui-rest-api.changes
+++ b/package/libyui-rest-api.changes
@@ -1,8 +1,20 @@
 -------------------------------------------------------------------
+Mon Jun  8 14:37:04 UTC 2020 - Rodion Iafarov <riafarov@suse.com>
+
+- Add support for YDateField and YTimeField (bsc#1139747)
+- Trigger update on YCombobox, YSelectionBox, YInputField, YMultiSelectionBox
+- Allow setting text in editable YComboBox
+- Allow selecting row in the table by row id
+- Return json format consistently
+- Add support for YDateField and YTimeField
+- Add support for YCheckBoxFrame
+- 0.5.0
+
+-------------------------------------------------------------------
 Thu Jun  4 12:21:23 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use new parent lib SO version libyui.so.12 (bsc#1172513)
-- 0.4.1 
+- 0.4.1
 
 -------------------------------------------------------------------
 Wed Feb  5 12:09:35 UTC 2020 - Oleksandr Orlov <oorlov@suse.com>

--- a/package/libyui-rest-api.spec
+++ b/package/libyui-rest-api.spec
@@ -18,7 +18,7 @@
 
 %define so_version 12
 %define bin_name %{name}%{so_version}
-%define libyui_devel_version libyui-devel >= 3.10.0
+%define libyui_devel_version libyui-devel >= 3.10.1
 
 Name:           libyui-rest-api
 Version:        0.4.1

--- a/src/YHttpAppHandler.cc
+++ b/src/YHttpAppHandler.cc
@@ -27,7 +27,7 @@
 void YHttpAppHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     Json::Value info;
     YApplication *app = YUI::app();
@@ -56,15 +56,15 @@ void YHttpAppHandler::process_request(struct MHD_Connection* connection,
     std::map<std::string,std::string> relnotes = app->releaseNotes();
     if (!relnotes.empty()) {
         Json::Value relnotes_json;
-        
+
         for(const auto &pair: relnotes) {
             relnotes_json[pair.first] = pair.second;
         }
-        
+
         info["release_notes"] = relnotes_json;
     }
-    
+
     YJsonSerializer::save(info, body);
     error_code = MHD_HTTP_OK;
-    content_encoding = "application/json";
+    content_type = "application/json";
 }

--- a/src/YHttpAppHandler.h
+++ b/src/YHttpAppHandler.h
@@ -32,7 +32,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw);
+        std::string& content_type, bool *redraw);
 };
 
 #endif // YHttpAppHandler_h

--- a/src/YHttpDialogHandler.cc
+++ b/src/YHttpDialogHandler.cc
@@ -22,7 +22,7 @@
 void YHttpDialogHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     if (auto dialog = YDialog::topmostDialog(false))  {
         YJsonSerializer::serialize(dialog, body);
@@ -33,5 +33,5 @@ void YHttpDialogHandler::process_request(struct MHD_Connection* connection,
         error_code = MHD_HTTP_NOT_FOUND;
     }
 
-    content_encoding = "application/json";
+    content_type = "application/json";
 }

--- a/src/YHttpDialogHandler.h
+++ b/src/YHttpDialogHandler.h
@@ -32,7 +32,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw);
+        std::string& content_type, bool *redraw);
 
 };
 

--- a/src/YHttpHandler.cc
+++ b/src/YHttpHandler.cc
@@ -27,24 +27,23 @@ int YHttpHandler::handle(struct MHD_Connection* connection,
         size_t* upload_data_size, bool *redraw)
 {
     std::ostringstream body_s;
-    std::string encoding;
+    std::string content_type;
     int error_code;
 
     process_request(connection, url, method, upload_data, upload_data_size,
-      body_s, error_code, encoding, redraw);
+      body_s, error_code, content_type, redraw);
 
     std::string body_str = body_s.str();
     struct MHD_Response *response = MHD_create_response_from_buffer (body_str.length(),
 		      (void *) body_str.c_str(), MHD_RESPMEM_MUST_COPY);
 
-    if (!encoding.empty())
-        MHD_add_response_header(response, MHD_HTTP_HEADER_CONTENT_ENCODING, encoding.c_str());
+    if (!content_type.empty())
+        MHD_add_response_header(response, MHD_HTTP_HEADER_CONTENT_TYPE, content_type.c_str());
 
     yuiMilestone() << "Sending response: code: " << error_code << ", body size: " << body_str.length()
-      << ", content type: " << encoding << std::endl;
+      << ", content type: " << content_type << std::endl;
 
     int ret = MHD_queue_response(connection, error_code, response);
     MHD_destroy_response (response);
     return ret;
 }
-

--- a/src/YHttpHandler.cc
+++ b/src/YHttpHandler.cc
@@ -14,9 +14,10 @@
   Floor, Boston, MA 02110-1301 USA
 */
 
+#include <json/json.h>
 #include <microhttpd.h>
-#include <sstream>
 
+#include "YJsonSerializer.h"
 #include "YHttpHandler.h"
 
 #define YUILogComponent "rest-api"
@@ -46,4 +47,12 @@ int YHttpHandler::handle(struct MHD_Connection* connection,
     int ret = MHD_queue_response(connection, error_code, response);
     MHD_destroy_response (response);
     return ret;
+}
+
+int YHttpHandler::handle_error(std::ostream& body, std::string error, int error_code)
+{
+    Json::Value response;
+    response["error"] = error;
+    YJsonSerializer::save(response, body);
+    return error_code;
 }

--- a/src/YHttpHandler.h
+++ b/src/YHttpHandler.h
@@ -41,6 +41,8 @@ protected:
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
         std::string& content_type, bool *redraw) = 0;
+
+    int handle_error(std::ostream& body, std::string error, int error_code);
 };
 
 #endif // YHttpHandler_h

--- a/src/YHttpHandler.h
+++ b/src/YHttpHandler.h
@@ -40,7 +40,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw) = 0;
+        std::string& content_type, bool *redraw) = 0;
 };
 
 #endif // YHttpHandler_h

--- a/src/YHttpRootHandler.cc
+++ b/src/YHttpRootHandler.cc
@@ -34,7 +34,7 @@ const std::string YHttpRootHandler::documentation_url = "https://github.com/liby
 void YHttpRootHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     if (accepts_html(connection))
     {
@@ -53,14 +53,14 @@ void YHttpRootHandler::process_request(struct MHD_Connection* connection,
 "    </p>"
 "    </body>"
 "</html>";
-        content_encoding = "text/html";
+        content_type = "text/html";
     }
     else
     {
         Json::Value info;
         info["documentation_url"] = documentation_url;
         YJsonSerializer::save(info, body);
-        content_encoding = "application/json";
+        content_type = "application/json";
     }
 
     error_code = MHD_HTTP_OK;

--- a/src/YHttpRootHandler.h
+++ b/src/YHttpRootHandler.h
@@ -31,7 +31,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw);
+        std::string& content_type, bool *redraw);
 
 private:
     static const std::string documentation_url;

--- a/src/YHttpServer.cc
+++ b/src/YHttpServer.cc
@@ -41,7 +41,9 @@
 #include "YHttpWidgetsHandler.h"
 #include "YHttpWidgetsActionHandler.h"
 
+
 YHttpServer * YHttpServer::_yserver = 0;
+YHttpWidgetsActionHandler * YHttpServer::_widget_action_handler = 0;
 
 const char *auth_error_body = "{ \"error\" : \"Authentication error, wrong user name or password\" }\n";
 
@@ -79,10 +81,11 @@ struct in6_addr listen_address_v6(bool remote)
     return (remote) ? in6addr_any : in6addr_loopback;
 }
 
-YHttpServer::YHttpServer() : server_v4(nullptr), server_v6(nullptr), redraw(false)
+YHttpServer::YHttpServer(YHttpWidgetsActionHandler * widgets_action_handler)
+    : server_v4(nullptr), server_v6(nullptr), redraw(false)
 {
     _yserver = this;
-
+    _widget_action_handler = widgets_action_handler;
     // authorization user set?
     if (const char *user = getenv(YUI_AUTH_USER))
     {
@@ -254,7 +257,7 @@ void YHttpServer::start()
     mount("/", "GET", new YHttpRootHandler(), false);
     mount("/dialog", "GET", new YHttpDialogHandler());
     mount("/widgets", "GET", new YHttpWidgetsHandler());
-    mount("/widgets", "POST", new YHttpWidgetsActionHandler());
+    mount("/widgets", "POST", get_widget_action_handler());
     mount("/application", "GET", new YHttpAppHandler());
     mount("/version", "GET", new YHttpVersionHandler(), false);
 

--- a/src/YHttpServer.cc
+++ b/src/YHttpServer.cc
@@ -219,7 +219,7 @@ requestHandler(void *srv,
     {
         struct MHD_Response *response = MHD_create_response_from_buffer(strlen(auth_error_body),
             (void *) auth_error_body, MHD_RESPMEM_PERSISTENT);
-        MHD_add_response_header(response, MHD_HTTP_HEADER_CONTENT_ENCODING, "application/json");
+        MHD_add_response_header(response, MHD_HTTP_HEADER_CONTENT_TYPE, "application/json");
         return MHD_queue_basic_auth_fail_response(connection, "libyui realm", response);
     }
 

--- a/src/YHttpServer.cc
+++ b/src/YHttpServer.cc
@@ -69,6 +69,18 @@ bool remote_access()
     return false;
 }
 
+unsigned int port_reuse()
+{
+    // for security reasons allow only one process to use this port by default
+    if ((getenv( YUI_REUSE_PORT ) && strcmp(getenv( YUI_REUSE_PORT ), "1") == 0))
+    {
+        yuiWarning() << "Warning: Allowing socket reuse by other processes!" << std::endl;
+        return (unsigned int) 1;
+    }
+    yuiMilestone() << "Port reuse is not allowed." << std::endl;
+    return (unsigned int) 0;
+}
+
 // return the IPv4 listen address (localhost or all)
 in_addr_t listen_address_v4(bool remote)
 {
@@ -277,9 +289,8 @@ void YHttpServer::start()
                         &onConnect, this,
                         // handler for processing requests
                         &requestHandler, this,
-                        // disable reusing the socket for multiple processes,
-                        // for security reasons allow only one process to use this port
-                        MHD_OPTION_LISTENING_ADDRESS_REUSE, (unsigned int) 0,
+                        // allow or forbid reusing the socket for multiple processes
+                        MHD_OPTION_LISTENING_ADDRESS_REUSE, port_reuse(),
                         // set the port and interface to listen to
                         MHD_OPTION_SOCK_ADDR, &server_socket,
                         // finish the argument list
@@ -303,7 +314,7 @@ void YHttpServer::start()
                         &requestHandler, this,
                         // disable reusing the socket for multiple processes,
                         // for security reasons allow only one process to use this port
-                        MHD_OPTION_LISTENING_ADDRESS_REUSE, (unsigned int) 0,
+                        MHD_OPTION_LISTENING_ADDRESS_REUSE, port_reuse(),
                         // set the port and interface to listen to
                         MHD_OPTION_SOCK_ADDR, &server_socket_v6,
                         // finish the argument list

--- a/src/YHttpServer.h
+++ b/src/YHttpServer.h
@@ -22,6 +22,7 @@
 
 #include "YHttpServerSockets.h"
 #include "YHttpMount.h"
+#include "YHttpWidgetsActionHandler.h"
 
 // environment variables
 #define YUITest_HTTP_REMOTE "YUI_HTTP_REMOTE"
@@ -51,7 +52,13 @@ public:
 
     static int port_num();
 
-    YHttpServer();
+    /**
+     * Constructor to override widgets action handler. Is used in case there
+     * are UI specific actions for the widget.
+     **/
+    YHttpServer( YHttpWidgetsActionHandler * widgets_action_handler );
+
+    YHttpServer() : YHttpServer( new YHttpWidgetsActionHandler() ) {};
 
     ~YHttpServer();
 
@@ -90,10 +97,14 @@ private:
     std::vector<YHttpMount> _mounts;
     bool redraw;
     static YHttpServer * _yserver;
-
+    static YHttpWidgetsActionHandler * _widget_action_handler;
     // HTTP Basic Auth credentials
     std::string auth_user;
     std::string auth_passwd;
+
+    static YHttpWidgetsActionHandler * get_widget_action_handler() { return _widget_action_handler; }
+
+protected:
 };
 
 

--- a/src/YHttpServer.h
+++ b/src/YHttpServer.h
@@ -29,6 +29,7 @@
 #define YUITest_HTTP_PORT   "YUI_HTTP_PORT"
 #define YUI_AUTH_USER       "YUI_AUTH_USER"
 #define YUI_AUTH_PASSWD     "YUI_AUTH_PASSWD"
+#define YUI_REUSE_PORT      "YUI_REUSE_PORT"
 
 #define YUI_API_VERSION     "v1"
 

--- a/src/YHttpVersionHandler.cc
+++ b/src/YHttpVersionHandler.cc
@@ -25,12 +25,12 @@
 void YHttpVersionHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     Json::Value info;
     info["api_version"] = YUI_API_VERSION;
     YJsonSerializer::save(info, body);
 
-    content_encoding = "application/json";
+    content_type = "application/json";
     error_code = MHD_HTTP_OK;
 }

--- a/src/YHttpVersionHandler.h
+++ b/src/YHttpVersionHandler.h
@@ -32,7 +32,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw);
+        std::string& content_type, bool *redraw);
 };
 
 #endif // YHttpVersionHandler_h

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -44,6 +44,9 @@
 
 #include "YHttpWidgetsActionHandler.h"
 
+#define YUILogComponent "rest-api"
+#include "YUILog.h"
+
 void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
@@ -64,7 +67,7 @@ void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connectio
         else
         {
             body << "{ \"error\" : \"No search criteria provided\" }" << std::endl;
-            _error_code = MHD_HTTP_NOT_FOUND;
+            error_code = MHD_HTTP_NOT_FOUND;
             return;
         }
 
@@ -102,9 +105,8 @@ void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connectio
     content_type = "application/json";
 }
 
-int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &action, struct MHD_Connection *connection, std::ostream& body) {
-
-    yuiMilestone() << "Starting action: " << action << std::endl;
+int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &action, struct MHD_Connection *connection, std::ostream& body)
+{
 
     // TODO improve this, maybe use better names for the actions...
 

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -16,6 +16,7 @@
 
 #include "YCheckBox.h"
 #include "YComboBox.h"
+#include "YDateField.h"
 #include "YDialog.h"
 #include "YDumbTab.h"
 #include "YInputField.h"
@@ -276,6 +277,14 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         {
             return action_handler<YMultiLineEdit>( widget, body, [&] (YMultiLineEdit *input) {
                 yuiMilestone() << "Setting value for YMultiLineEdit \"" << input->label() << '"' << std::endl;
+                input->setKeyboardFocus();
+                input->setValue(value);
+            } );
+        }
+        else if ( dynamic_cast<YDateField*>(widget) )
+        {
+            return action_handler<YDateField>( widget, body, [&] (YDateField *input) {
+                yuiMilestone() << "Setting value for YDateField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
             } );

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -28,6 +28,7 @@
 #include "YRadioButton.h"
 #include "YRichText.h"
 #include "YTable.h"
+#include "YTimeField.h"
 #include "YTree.h"
 #include "YTreeItem.h"
 #include "YSelectionBox.h"
@@ -287,6 +288,16 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 yuiMilestone() << "Setting value for YDateField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
+                input->activate();
+            } );
+        }
+        else if ( dynamic_cast<YTimeField*>(widget) )
+        {
+            return action_handler<YTimeField>( widget, body, [&] (YTimeField *input) {
+                yuiMilestone() << "Setting value for YTimeField \"" << input->label() << '"' << std::endl;
+                input->setKeyboardFocus();
+                input->setValue(value);
+                input->activate();
             } );
         }
 

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -288,8 +288,8 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the table" << std::endl;
-                    throw YUIException("Item cannot be found in the table");
+                    body << '"' << value << "\" item cannot be found in the combobox" << std::endl;
+                    throw YUIException("Item cannot be found in the combobox");
                 }
             } );
         }
@@ -369,6 +369,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                     yuiMilestone() << "Activating selection box \"" << sb->label() << '"' << std::endl;
                     sb->setKeyboardFocus();
                     sb->selectItem(item);
+                    sb->activate();
                 }
                 else
                 {

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -27,8 +27,6 @@
 #include "YTable.h"
 #include "YTree.h"
 #include "YTreeItem.h"
-#include "YSelectionBox.h"
-#include "YMultiSelectionBox.h"
 #include "YWidgetID.h"
 
 #include <codecvt>
@@ -428,3 +426,5 @@ void YHttpWidgetsActionHandler::activate_widget( YDateField * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget( YInputField * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget( YTimeField * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget ( YSelectionBox * widget ) {};
+
+void YHttpWidgetsActionHandler::activate_widget ( YMultiSelectionBox * widget, YItem * item ) {};

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -278,7 +278,19 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             return action_handler<YComboBox>(widget, [&] (YComboBox *cb) {
                 yuiMilestone() << "Activating ComboBox \"" << cb->label() << '"' << std::endl;
                 cb->setKeyboardFocus();
-                cb->setValue(value);
+                // cb->setValue(value);
+                YItem * item = cb->findItem(value);
+                if ( item )
+                {
+                        yuiMilestone() << "Activating Combobox \"" << cb->label() << '"' << std::endl;
+                        cb->selectItem(item);
+                        cb->activate();
+                }
+                else
+                {
+                    body << '"' << value << "\" item cannot be found in the table" << std::endl;
+                    throw YUIException("Item cannot be found in the table");
+                }
             } );
         }
         else if( dynamic_cast<YTable*>(widget) )

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -21,6 +21,7 @@
 #include "YItemSelector.h"
 #include "YMenuButton.h"
 #include "YMultiLineEdit.h"
+#include "YProperty.h"
 #include "YPushButton.h"
 #include "YRadioButton.h"
 #include "YRichText.h"
@@ -132,8 +133,20 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 if (checkbox->isChecked()) return;
                 yuiMilestone() << "Checking \"" << checkbox->label() << '"' << std::endl;
                 checkbox->setKeyboardFocus();
-                checkbox->setChecked(true);
+                checkbox->setChecked( true );
             } );
+        }
+        else if ( dynamic_cast<YCheckBoxFrame*>(widget) )
+        {
+            return action_handler<YCheckBoxFrame>( widget,
+                                                   body,
+                                                   [&] (YCheckBoxFrame *cbframe) {
+                yuiMilestone() << "Checking \"" << cbframe->label() << '"' << std::endl;
+                cbframe->setKeyboardFocus();
+                cbframe->setValue( true );
+                activate_widget( cbframe );
+            },
+                                                    true );
         }
         else
         {
@@ -168,6 +181,15 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 checkbox->setChecked(false);
             } );
         }
+        else if ( dynamic_cast<YCheckBoxFrame*>(widget) )
+        {
+            return action_handler<YCheckBoxFrame>( widget, body, [&] (YCheckBoxFrame *cbframe) {
+                yuiMilestone() << "Unchecking \"" << cbframe->label() << '"' << std::endl;
+                cbframe->setKeyboardFocus();
+                cbframe->setValue( false );
+                activate_widget( cbframe );
+            } );
+        }
         else
         {
             std::string value;
@@ -198,6 +220,19 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 checkbox->setKeyboardFocus();
                 checkbox->setChecked(!checkbox->isChecked());
             } );
+        }
+        else if ( dynamic_cast<YCheckBoxFrame*>(widget) )
+        {
+            return action_handler<YCheckBoxFrame>( widget,
+                                                   body,
+                                                   [&] (YCheckBoxFrame *cbframe) {
+                yuiMilestone() << "Toggling \"" << cbframe->label() << '"' << std::endl;
+                cbframe->setKeyboardFocus();
+                activate_widget( cbframe );
+                cbframe->setValue( !cbframe->value() );
+                activate_widget( cbframe );
+            },
+                                                   true ); //Allowing acting on disabled, as do not know state in advance
         }
         else
         {
@@ -469,6 +504,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
     return MHD_HTTP_OK;
 }
 
+void YHttpWidgetsActionHandler::activate_widget( YCheckBoxFrame * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget( YComboBox * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget( YDateField * widget ) {};
 void YHttpWidgetsActionHandler::activate_widget( YInputField * widget ) {};

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -252,7 +252,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             return action_handler<YDateField>( widget, body, [&] (YDateField *input) {
                 yuiMilestone() << "Setting value for YDateField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
-                input->setValue(value);
+                input->setValue( value );
                 activate_widget( input );
             } );
         }
@@ -261,8 +261,24 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             return action_handler<YTimeField>( widget, body, [&] (YTimeField *input) {
                 yuiMilestone() << "Setting value for YTimeField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
-                input->setValue(value);
+                input->setValue( value );
                 activate_widget( input );
+            } );
+        }
+        else if ( dynamic_cast<YComboBox*>(widget) )
+        {
+            YComboBox* cb = dynamic_cast<YComboBox*>(widget);
+            if( !cb->editable() )
+            {
+                body << "{ \"error\" : \"Combobox '" << cb->label() << "' is not editable \" }" << std::endl;
+                return MHD_HTTP_UNPROCESSABLE_ENTITY;
+            }
+
+            return action_handler<YComboBox>( widget, body, [&] (YComboBox *cb) {
+                yuiMilestone() << "Setting value for YComboBox \"" << cb->label() << '"' << std::endl;
+                cb->setKeyboardFocus();
+                cb->setValue( value );
+                activate_widget( cb );
             } );
         }
 

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -121,39 +121,6 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 button->activate();
             } );
         }
-        else if ( dynamic_cast<YRichText*>(widget) )
-        {
-            std::string value;
-            if ( const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "value") )
-                value = val;
-            return action_handler<YRichText>(widget, body, [&] (YRichText *rt) {
-                yuiMilestone() << "Activating hyperlink on richtext: \"" << value << '"' << std::endl;
-                rt->setKeyboardFocus();
-                rt->activateLink(value);
-            } );
-        }
-        else if( dynamic_cast<YMenuButton*>(widget) )
-        {
-            std::string value;
-            if ( const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "value") )
-                value = val;
-            return action_handler<YMenuButton>( widget, body, [&] (YMenuButton *mb) {
-                // Vector of string to store path to the tree item
-                std::vector<std::string> path;
-                boost::split( path, value, boost::is_any_of( TreePathDelimiter ) );
-                YMenuItem * item = mb->findItem( path );
-                if ( item )
-                {
-                    yuiMilestone() << "Activating Item by path :" << value << " in \"" << mb->label() << "\" MenuButton" << std::endl;
-                    mb->setKeyboardFocus();
-                    mb->activateItem( item );
-                }
-                else
-                {
-                    throw YUIException("Item with path: '" + value + "' cannot be found in the MenuButton widget");
-                }
-            } );
-        }
 
         body << "{ \"error\" : Action 'press' is not supported for the selected widget: \"" << widget->widgetClass() << "\" }" << std::endl;
         return MHD_HTTP_NOT_FOUND;
@@ -419,6 +386,33 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         else if( dynamic_cast<YItemSelector*>(widget) )
         {
             return get_item_selector_handler( dynamic_cast<YItemSelector*>(widget), value, body, 1 );
+        }
+        else if ( dynamic_cast<YRichText*>(widget) )
+        {
+            return action_handler<YRichText>(widget, body, [&] (YRichText *rt) {
+                yuiMilestone() << "Activating hyperlink on richtext: \"" << value << '"' << std::endl;
+                rt->setKeyboardFocus();
+                rt->activateLink(value);
+            } );
+        }
+        else if( dynamic_cast<YMenuButton*>(widget) )
+        {
+            return action_handler<YMenuButton>( widget, body, [&] (YMenuButton *mb) {
+                // Vector of string to store path to the tree item
+                std::vector<std::string> path;
+                boost::split( path, value, boost::is_any_of( TreePathDelimiter ) );
+                YMenuItem * item = mb->findItem( path );
+                if ( item )
+                {
+                    yuiMilestone() << "Activating Item by path :" << value << " in \"" << mb->label() << "\" MenuButton" << std::endl;
+                    mb->setKeyboardFocus();
+                    mb->activateItem( item );
+                }
+                else
+                {
+                    throw YUIException("Item with path: '" + value + "' cannot be found in the MenuButton widget");
+                }
+            } );
         }
 
         body << "{ \"error\" : \"Action 'select' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -69,7 +69,8 @@ void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connectio
             body << "{ \"error\" : \"Widget not found\" }" << std::endl;
             error_code = MHD_HTTP_NOT_FOUND;
         }
-        else if ( const char* action = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "action") )
+
+        if ( const char* action = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "action") )
         {
             if( widgets.size() != 1 )
             {

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -15,11 +15,8 @@
 */
 
 #include "YCheckBox.h"
-#include "YComboBox.h"
-#include "YDateField.h"
 #include "YDialog.h"
 #include "YDumbTab.h"
-#include "YInputField.h"
 #include "YIntField.h"
 #include "YItemSelector.h"
 #include "YMenuButton.h"
@@ -28,7 +25,6 @@
 #include "YRadioButton.h"
 #include "YRichText.h"
 #include "YTable.h"
-#include "YTimeField.h"
 #include "YTree.h"
 #include "YTreeItem.h"
 #include "YSelectionBox.h"
@@ -234,6 +230,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 yuiMilestone() << "Setting value for InputField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
+                activate_widget( input );
             } );
         }
         else if ( dynamic_cast<YIntField*>(widget) )
@@ -425,3 +422,9 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
 
     return MHD_HTTP_OK;
 }
+
+void YHttpWidgetsActionHandler::activate_widget( YComboBox * widget ) {};
+void YHttpWidgetsActionHandler::activate_widget( YDateField * widget ) {};
+void YHttpWidgetsActionHandler::activate_widget( YInputField * widget ) {};
+void YHttpWidgetsActionHandler::activate_widget( YTimeField * widget ) {};
+void YHttpWidgetsActionHandler::activate_widget ( YSelectionBox * widget ) {};

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -31,6 +31,7 @@
 #include "YTreeItem.h"
 #include "YSelectionBox.h"
 #include "YMultiSelectionBox.h"
+#include "YWidgetID.h"
 
 #include <codecvt>
 #include <vector>
@@ -44,7 +45,7 @@
 void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     if ( YDialog::topmostDialog(false) )
     {
@@ -93,7 +94,7 @@ void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connectio
         error_code = MHD_HTTP_NOT_FOUND;
     }
 
-    content_encoding = "application/json";
+    content_type = "application/json";
 }
 
 int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &action, struct MHD_Connection *connection, std::ostream& body) {
@@ -108,7 +109,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         yuiMilestone() << "Received action: press" << std::endl;
         if (dynamic_cast<YPushButton*>(widget))
         {
-            return action_handler<YPushButton>(widget, [] (YPushButton *button)
+            return action_handler<YPushButton>( widget, body, [] (YPushButton *button)
             {
                 yuiMilestone() << "Pressing button \"" << button->label() << '"' << std::endl;
                 button->setKeyboardFocus();
@@ -120,7 +121,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             std::string value;
             if ( const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "value") )
                 value = val;
-            return action_handler<YRichText>(widget, [&] (YRichText *rt) {
+            return action_handler<YRichText>(widget, body, [&] (YRichText *rt) {
                 yuiMilestone() << "Activating hyperlink on richtext: \"" << value << '"' << std::endl;
                 rt->setKeyboardFocus();
                 rt->activateLink(value);
@@ -131,7 +132,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             std::string value;
             if ( const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "value") )
                 value = val;
-            return action_handler<YMenuButton>(widget, [&] (YMenuButton *mb) {
+            return action_handler<YMenuButton>( widget, body, [&] (YMenuButton *mb) {
                 // Vector of string to store path to the tree item
                 std::vector<std::string> path;
                 boost::split( path, value, boost::is_any_of( TreePathDelimiter ) );
@@ -144,23 +145,20 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << "Item with path: \"" << value << "\" cannot be found in the MenuButton widget" << std::endl;
-                    throw YUIException("Item cannot be found in the MenuButton widget");
+                    throw YUIException("Item with path: '" + value + "' cannot be found in the MenuButton widget");
                 }
             } );
         }
-        else
-        {
-            body << "Action is not supported for the selected widget: " << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
-        }
+
+        body << "{ \"error\" : Action 'press' is not supported for the selected widget: \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
     // check a checkbox
     else if ( action == "check" )
     {
         if ( dynamic_cast<YCheckBox*>(widget) )
         {
-            return action_handler<YCheckBox>(widget, [] (YCheckBox *checkbox) {
+            return action_handler<YCheckBox>( widget, body, [] (YCheckBox *checkbox) {
                 if (checkbox->isChecked()) return;
                 yuiMilestone() << "Checking \"" << checkbox->label() << '"' << std::endl;
                 checkbox->setKeyboardFocus();
@@ -182,17 +180,17 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             {
                 return get_item_selector_handler( selector, value, body, 1 );
             }
-
-            body << "Action 'check' is not supported for the selected widget" << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
         }
+
+        body << "Action 'check' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
     // uncheck a checkbox
     else if ( action == "uncheck" )
     {
         if ( dynamic_cast<YCheckBox*>(widget) )
         {
-            return action_handler<YCheckBox>(widget, [] (YCheckBox *checkbox) {
+            return action_handler<YCheckBox>( widget, body, [] (YCheckBox *checkbox) {
                 if (!checkbox->isChecked()) return;
                 yuiMilestone() << "Unchecking \"" << checkbox->label() << '"' << std::endl;
                 checkbox->setKeyboardFocus();
@@ -214,16 +212,17 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             {
                 return get_item_selector_handler( selector, value, body, 0 );
             }
-
-            body << "Action 'uncheck' is not supported for the selected widget" << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
         }
+
+        body << "{ \"error\" : \"Action 'uncheck' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
     // toggle a checkbox (reverse the state)
-    else if ( action == "toggle" ) {
+    else if ( action == "toggle" )
+    {
         if ( dynamic_cast<YCheckBox*>(widget) )
         {
-            return action_handler<YCheckBox>(widget, [] (YCheckBox *checkbox) {
+            return action_handler<YCheckBox>( widget, body, [] (YCheckBox *checkbox) {
                 yuiMilestone() << "Toggling \"" << checkbox->label() << '"' << std::endl;
                 checkbox->setKeyboardFocus();
                 checkbox->setChecked(!checkbox->isChecked());
@@ -244,10 +243,10 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             {
                 return get_item_selector_handler( selector, value, body );
             }
-
-            body << "Action 'toggle' is not supported for the selected widget" << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
         }
+
+        body << "{ \"error\" : \"Action 'toggle' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
     // enter input field text
     else if ( action == "enter_text" )
@@ -258,7 +257,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
 
         if ( dynamic_cast<YInputField*>(widget) )
         {
-            return action_handler<YInputField>(widget, [&] (YInputField *input) {
+            return action_handler<YInputField>( widget, body, [&] (YInputField *input) {
                 yuiMilestone() << "Setting value for InputField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
@@ -266,7 +265,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         }
         else if ( dynamic_cast<YIntField*>(widget) )
         {
-            return action_handler<YIntField>(widget, [&] (YIntField *input) {
+            return action_handler<YIntField>( widget, body, [&] (YIntField *input) {
                 yuiMilestone() << "Setting value for YIntField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(atoi(value.c_str()));
@@ -274,17 +273,15 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         }
         else if ( dynamic_cast<YMultiLineEdit*>(widget) )
         {
-            return action_handler<YMultiLineEdit>(widget, [&] (YMultiLineEdit *input) {
+            return action_handler<YMultiLineEdit>( widget, body, [&] (YMultiLineEdit *input) {
                 yuiMilestone() << "Setting value for YMultiLineEdit \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
             } );
         }
-        else
-        {
-            body << "Action is not supported for the selected widget: " << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
-        }
+
+        body << "{ \"error\" : \"Action 'enter_text' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
     else if ( action == "select" )
     {
@@ -294,21 +291,20 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
 
         if ( dynamic_cast<YComboBox*>(widget) )
         {
-            return action_handler<YComboBox>(widget, [&] (YComboBox *cb) {
+            return action_handler<YComboBox>( widget, body, [&] (YComboBox *cb) {
                 yuiMilestone() << "Activating ComboBox \"" << cb->label() << '"' << std::endl;
                 cb->setKeyboardFocus();
                 // cb->setValue(value);
                 YItem * item = cb->findItem(value);
                 if ( item )
                 {
-                        yuiMilestone() << "Activating Combobox \"" << cb->label() << '"' << std::endl;
-                        cb->selectItem(item);
-                        cb->activate();
+                    yuiMilestone() << "Activating Combobox \"" << cb->label() << '"' << std::endl;
+                    cb->selectItem(item);
+                    cb->activate();
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the combobox" << std::endl;
-                    throw YUIException("Item cannot be found in the combobox");
+                    throw YUIException("Item: '" + value + "' cannot be found in the combobox");
                 }
             } );
         }
@@ -317,7 +313,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
             int column_id = 0;
             if ( const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "column") )
                 column_id = atoi(val);
-            return action_handler<YTable>(widget, [&] (YTable *tb) {
+            return action_handler<YTable>( widget, body, [&] (YTable *tb) {
                 YItem * item = tb->findItem(value, column_id);
                 if ( item )
                 {
@@ -327,14 +323,13 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the table" << std::endl;
-                    throw YUIException("Item cannot be found in the table");
+                    throw YUIException("Item: '" + value + "' cannot be found in the table");
                 }
             } );
         }
         else if( dynamic_cast<YTree*>(widget) )
         {
-            return action_handler<YTree>(widget, [&] (YTree *tree) {
+            return action_handler<YTree>( widget, body, [&] (YTree *tree) {
                 // Vector of string to store path to the tree item
                 std::vector<std::string> path;
                 boost::split( path, value, boost::is_any_of( TreePathDelimiter ) );
@@ -348,14 +343,13 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the tree" << std::endl;
-                    throw YUIException("Item cannot be found in the tree");
+                    throw YUIException("Item: '" + value + "' cannot be found in the tree");
                 }
             } );
         }
         else if ( dynamic_cast<YDumbTab*>(widget) )
         {
-            return action_handler<YDumbTab>(widget, [&] (YDumbTab *tab) {
+            return action_handler<YDumbTab>( widget, body, [&] (YDumbTab *tab) {
                 YItem * item = tab->findItem( value );
                 if ( item )
                 {
@@ -366,14 +360,13 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the tree" << std::endl;
-                    throw YUIException("Item cannot be found in the tree");
+                    throw YUIException("Item: '" + value + "' cannot be found among tabs");
                 }
             } );
         }
         else if( dynamic_cast<YRadioButton*>(widget) )
         {
-            return action_handler<YRadioButton>(widget, [&] (YRadioButton *rb) {
+            return action_handler<YRadioButton>( widget, body, [&] (YRadioButton *rb) {
                 yuiMilestone() << "Activating RadioButton \"" << rb->label() << '"' << std::endl;
                 rb->setKeyboardFocus();
                 rb->setValue(true);
@@ -381,7 +374,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         }
         else if( dynamic_cast<YSelectionBox*>(widget) )
         {
-            return action_handler<YSelectionBox>(widget, [&] (YSelectionBox *sb) {
+            return action_handler<YSelectionBox>( widget, body, [&] (YSelectionBox *sb) {
                 YItem * item = sb->findItem( value );
                 if ( item )
                 {
@@ -392,8 +385,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 }
                 else
                 {
-                    body << '"' << value << "\" item cannot be found in the selection box" << std::endl;
-                    throw YUIException("Item cannot be found in the selection box");
+                    throw YUIException("Item: '" + value + "' cannot be found in the selection box");
                 }
             } );
         }
@@ -405,15 +397,10 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         {
             return get_item_selector_handler( dynamic_cast<YItemSelector*>(widget), value, body, 1 );
         }
-        else
-        {
-            body << "Action is not supported for the selected widget " << widget->widgetClass() << std::endl;
-            return MHD_HTTP_NOT_FOUND;
-        }
+
+        body << "{ \"error\" : \"Action 'select' is not supported for the selected widget \"" << widget->widgetClass() << "\" }" << std::endl;
+        return MHD_HTTP_NOT_FOUND;
     }
-    // TODO: more actions
-    // else if (action == "enter") {
-    // }
     else
     {
         body << "{ \"error\" : \"Unknown action\" }" << std::endl;

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -114,13 +114,12 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
     if ( action == "press" )
     {
         yuiMilestone() << "Received action: press" << std::endl;
-        if (dynamic_cast<YPushButton*>(widget))
+        if ( dynamic_cast<YPushButton*>(widget) )
         {
-            return action_handler<YPushButton>( widget, body, [] (YPushButton *button)
-            {
+            return action_handler<YPushButton>( widget, body, [&] (YPushButton *button) {
                 yuiMilestone() << "Pressing button \"" << button->label() << '"' << std::endl;
                 button->setKeyboardFocus();
-                button->activate();
+                activate_widget( button );
             } );
         }
 
@@ -259,7 +258,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 yuiMilestone() << "Setting value for YDateField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
-                input->activate();
+                activate_widget( input );
             } );
         }
         else if ( dynamic_cast<YTimeField*>(widget) )
@@ -268,7 +267,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 yuiMilestone() << "Setting value for YTimeField \"" << input->label() << '"' << std::endl;
                 input->setKeyboardFocus();
                 input->setValue(value);
-                input->activate();
+                activate_widget( input );
             } );
         }
 
@@ -280,19 +279,17 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
         std::string value;
         if (const char* val = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "value"))
             value = val;
-
         if ( dynamic_cast<YComboBox*>(widget) )
         {
             return action_handler<YComboBox>( widget, body, [&] (YComboBox *cb) {
                 yuiMilestone() << "Activating ComboBox \"" << cb->label() << '"' << std::endl;
                 cb->setKeyboardFocus();
-                // cb->setValue(value);
                 YItem * item = cb->findItem(value);
                 if ( item )
                 {
                     yuiMilestone() << "Activating Combobox \"" << cb->label() << '"' << std::endl;
-                    cb->selectItem(item);
-                    cb->activate();
+                    cb->selectItem( item );
+                    activate_widget( cb );
                 }
                 else
                 {
@@ -330,8 +327,8 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 {
                     yuiMilestone() << "Activating Tree Item \"" << item->label() << '"' << std::endl;
                     tree->setKeyboardFocus();
-                    tree->selectItem(item);
-                    tree->activate();
+                    tree->selectItem( item );
+                    activate_widget( tree );
                 }
                 else
                 {
@@ -347,8 +344,8 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 {
                     yuiMilestone() << "Activating Tree Item \"" << item->label() << '"' << std::endl;
                     tab->setKeyboardFocus();
-                    tab->selectItem(item);
-                    tab->activate();
+                    tab->selectItem( item );
+                    activate_widget( tab );
                 }
                 else
                 {
@@ -372,8 +369,8 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 {
                     yuiMilestone() << "Activating selection box \"" << sb->label() << '"' << std::endl;
                     sb->setKeyboardFocus();
-                    sb->selectItem(item);
-                    sb->activate();
+                    sb->selectItem( item );
+                    activate_widget( sb );
                 }
                 else
                 {
@@ -408,7 +405,7 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 {
                     yuiMilestone() << "Activating Item by path :" << value << " in \"" << mb->label() << "\" MenuButton" << std::endl;
                     mb->setKeyboardFocus();
-                    mb->activateItem( item );
+                    activate_widget( mb, item );
                 }
                 else
                 {

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -25,6 +25,7 @@
 #include "YRadioButton.h"
 #include "YRichText.h"
 #include "YTable.h"
+#include "YTableItem.h"
 #include "YTree.h"
 #include "YTreeItem.h"
 #include "YWidgetID.h"
@@ -351,10 +352,10 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 column_id = atoi(val);
 
             return action_handler<YTable>( widget, body, [&] (YTable *tb) {
-                YItem * item = tb->findItem(value, column_id);
+                auto * item = dynamic_cast<YTableItem*>( tb->findItem( value, column_id ) );
                 if ( item )
                 {
-                        yuiMilestone() << "Activating Table \"" << tb->label() << '"' << std::endl;
+                        yuiMilestone() << "Activating Table \"" << tb->label() << "\" Item: \"" << item->label( column_id ) << "\"" << std::endl;
                         tb->setKeyboardFocus();
                         tb->selectItem( item );
                 }

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -323,18 +323,11 @@ int YHttpWidgetsActionHandler::do_action(YWidget *widget, const std::string &act
                 // Handle case when want select row by row number
                 return action_handler<YTable>( widget, body, [&] (YTable *tb) {
 
-                    if( row_id >= tb->itemsCount() ) {
+                    if( row_id >= tb->itemsCount() || row_id < 0 ) {
                         throw YUIException( "Table: '" + tb->label() + "' does NOT contain row #" + std::to_string( row_id ) );
                     }
-                    YItem * item = 0;
-                    int current_row = 0;
-                    for ( YItemConstIterator it = tb->itemsBegin(); it != tb->itemsEnd(); ++it )
-                    {
-                        item = *it;
-                        if( current_row++ == row_id )
-                            break;
-                    }
-                    if ( item )
+
+                    if ( YItem * item = tb->itemAt(row_id) )
                     {
                             yuiMilestone() << "Activating Table \"" << tb->label() << '"' << std::endl;
                             tb->setKeyboardFocus();

--- a/src/YHttpWidgetsActionHandler.cc
+++ b/src/YHttpWidgetsActionHandler.cc
@@ -63,7 +63,9 @@ void YHttpWidgetsActionHandler::process_request(struct MHD_Connection* connectio
         }
         else
         {
-            widgets = YWidgetFinder::all();
+            body << "{ \"error\" : \"No search criteria provided\" }" << std::endl;
+            _error_code = MHD_HTTP_NOT_FOUND;
+            return;
         }
 
         if ( widgets.empty() )

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -24,6 +24,7 @@
 
 #define TreePathDelimiter "|"
 
+#include "YCheckBoxFrame.h"
 #include "YComboBox.h"
 #include "YDateField.h"
 #include "YHttpHandler.h"
@@ -54,14 +55,25 @@ protected:
     int do_action( YWidget *widget, const std::string &action, struct MHD_Connection *connection, std::ostream& body );
 
     // TODO: move this somewhere else...
+
+    /**
+     * Processes action on the given widget.
+     * @tparam T the type of the widget handler will act on
+     * @param widget Widget to which action will be applied
+     * @param body HTTP response body stream
+     * @param handler_func Function which will be called with widget as an argument
+     * @param allow_disabled Some widgets get to disabled state, but are actually enabled, like YCheckBoxFrame
+     *     Not allowing by default, but allow explicit overrides for the exceptions.
+     * @return HTTP status code
+     */
     template<typename T>
-    int action_handler( YWidget *widget, std::ostream& body, std::function<void (T*)> handler_func ) {
+    int action_handler( YWidget *widget, std::ostream& body, std::function<void (T*)> handler_func, const bool allow_disabled = false ) {
         if (auto w = dynamic_cast<T*>(widget)) {
             try
             {
-                // allow changing only the enabled widgets, disabled ones
-                // cannot be changed by user from the UI, do not be more powerfull
-                if( !widget->isEnabled() )
+                // allow changing only the enabled widgets by default, as disabled ones
+                // cannot be changed by user from the UI in most of the cases
+                if( !widget->isEnabled() && !allow_disabled )
                 {
                     std::string error ("Cannot operate on disabled widget: ");
                     error.append( typeid(*widget).name() );
@@ -85,6 +97,7 @@ protected:
         return MHD_HTTP_OK;
     }
 
+
     /**
      * Define default widget activation and override only widgets which
      * either don't have method availaible in libyui or if they require
@@ -98,13 +111,14 @@ protected:
     /**
      * Declare methods where we need to override widget activation for nc or qt
      * We keep empty methods here, that it still works in case of missing
-     * override in the cihldren classes.
+     * override in the children classes.
      **/
+    virtual void activate_widget( YCheckBoxFrame * widget );
     virtual void activate_widget( YComboBox * widget );
     virtual void activate_widget( YDateField * widget );
     virtual void activate_widget( YInputField * widget );
     virtual void activate_widget( YTimeField * widget );
-    virtual void activate_widget ( YSelectionBox * widget );
+    virtual void activate_widget( YSelectionBox * widget );
 
     /**
      * Same as activate_widget, but for some widgets we also need to specify

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -71,8 +71,6 @@ protected:
             }
         }
         else {
-            // TODO: demangle the C++ names here ?
-            // https://gcc.gnu.org/onlinedocs/libstdc++/manual/ext_demangling.html
             return MHD_HTTP_NOT_FOUND;
         }
 
@@ -109,7 +107,7 @@ protected:
         selector->activateItem( item );
     }
 
-
+    virtual void activate_widget ( YMultiSelectionBox * widget, YItem * item );
 
     template<typename T>
     int get_item_selector_handler( T *widget, const std::string &value, std::ostream& body, const int state = -1 ) {
@@ -117,19 +115,16 @@ protected:
             YItem * item = selector->findItem( value );
             if ( item )
             {
-                // yuiMilestone() << "Activating item selector with item \"" << value << '"' << std::endl;
                 selector->setKeyboardFocus();
                 // Toggle in case state selector undefined
-                bool select = state < 0  ? !item->selected() :
-                              state == 0 ? false :
-                                           true;
+                bool select = state < 0  ? !item->selected() : (state != 0);
                 if( state < 0 )
                 {
                     select = !item->selected();
                 }
                 else
                 {
-                    select = state == 0 ? false : true;
+                    select = (state != 0);
                 }
                 item->setSelected( select );
                 selector->selectItem( item, select );

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -20,6 +20,7 @@
 #include "YHttpHandler.h"
 #include "YWidgetFinder.h"
 #include "YWidget.h"
+#include "YItem.h"
 
 #include <iostream>
 #include <functional>
@@ -80,7 +81,40 @@ private:
         return MHD_HTTP_OK;
     }
 
-    int get_item_selector_handler(YWidget *widget, const std::string &value, std::ostream& body, const int state = -1);
+
+    template<typename T>
+    int get_item_selector_handler(T *widget, const std::string &value, std::ostream& body, const int state = -1) {
+        return action_handler<T>(widget, [&] (T *selector) {
+            // auto selector = dynamic_cast<T*>(widget);
+
+            YItem * item = selector->findItem( value );
+            if ( item )
+            {
+                yuiMilestone() << "Activating item selector with item \"" << value << '"' << std::endl;
+                selector->setKeyboardFocus();
+                // Toggle in case state selector undefined
+                bool select = state < 0  ? !item->selected() :
+                              state == 0 ? false :
+                                           true;
+                if( state < 0 )
+                {
+                    select = !item->selected();
+                }
+                else
+                {
+                    select = state == 0 ? false : true;
+                }
+                item->setSelected( select );
+                selector->selectItem( item, select );
+                selector->activateItem( item );
+            }
+            else
+            {
+                body << '"' << value << "\" item cannot be found in the item selector" << std::endl;
+                throw YUIException("Item cannot be found in the item selector");
+            }
+        } );
+    }
 
 };
 

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <functional>
 #include <microhttpd.h>
+#include <sstream>
 
 #define TreePathDelimiter "|"
 
@@ -27,7 +28,6 @@
 #include "YDateField.h"
 #include "YHttpHandler.h"
 #include "YInputField.h"
-#include "YJsonSerializer.h"
 #include "YItem.h"
 #include "YMultiSelectionBox.h"
 #include "YSelectionBox.h"
@@ -63,8 +63,9 @@ protected:
                 // cannot be changed by user from the UI, do not be more powerfull
                 if( !widget->isEnabled() )
                 {
-                    body << "{ error: \"Cannot operate on disabled widget: '" << typeid(*widget).name() << "'\" }" << std::endl;
-                    return MHD_HTTP_UNPROCESSABLE_ENTITY;
+                    std::string error ("Cannot operate on disabled widget: ");
+                    error.append( typeid(*widget).name() );
+                    return handle_error( body, error, MHD_HTTP_UNPROCESSABLE_ENTITY );
                 }
                 if ( handler_func )
                     handler_func(w);
@@ -72,8 +73,9 @@ protected:
             // some widgets may throw an exception when setting invalid values
             catch (const YUIException &e)
             {
-                body << "{ error: \"" << typeid(*widget).name() << " " << e.what() << "\" }" << std::endl;
-                return MHD_HTTP_UNPROCESSABLE_ENTITY;
+                std::string error ("");
+                error.append( typeid(*widget).name() ).append( " " ).append( e.what() );
+                return handle_error( body, error, MHD_HTTP_UNPROCESSABLE_ENTITY );
             }
         }
         else {
@@ -142,11 +144,6 @@ protected:
             }
         } );
     }
-
-private:
-
-    int _error_code;
-
 };
 
 #endif // YHttpWidgetsActionHandler_h

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -61,7 +61,13 @@ protected:
             {
                 // allow changing only the enabled widgets, disabled ones
                 // cannot be changed by user from the UI, do not be more powerfull
-                if (handler_func && widget->isEnabled()) handler_func(w);
+                if( !widget->isEnabled() )
+                {
+                    body << "{ error: \"Cannot operate on disabled widget: '" << typeid(*widget).name() << "'\" }" << std::endl;
+                    return MHD_HTTP_UNPROCESSABLE_ENTITY;
+                }
+                if ( handler_func )
+                    handler_func(w);
             }
             // some widgets may throw an exception when setting invalid values
             catch (const YUIException &e)

--- a/src/YHttpWidgetsActionHandler.h
+++ b/src/YHttpWidgetsActionHandler.h
@@ -94,10 +94,11 @@ protected:
      * We keep empty methods here, that it still works in case of missing
      * override in the cihldren classes.
      **/
-    virtual void activate_widget( YComboBox * widget ) {};
-    virtual void activate_widget( YDateField * widget ) {};
-    virtual void activate_widget( YTimeField * widget ) {};
-    virtual void activate_widget ( YSelectionBox * selector ) {};
+    virtual void activate_widget( YComboBox * widget );
+    virtual void activate_widget( YDateField * widget );
+    virtual void activate_widget( YInputField * widget );
+    virtual void activate_widget( YTimeField * widget );
+    virtual void activate_widget ( YSelectionBox * widget );
 
     /**
      * Same as activate_widget, but for some widgets we also need to specify
@@ -107,6 +108,8 @@ protected:
     void activate_widget( T * selector, I *item ) {
         selector->activateItem( item );
     }
+
+
 
     template<typename T>
     int get_item_selector_handler( T *widget, const std::string &value, std::ostream& body, const int state = -1 ) {

--- a/src/YHttpWidgetsHandler.cc
+++ b/src/YHttpWidgetsHandler.cc
@@ -24,7 +24,7 @@
 void YHttpWidgetsHandler::process_request(struct MHD_Connection* connection,
     const char* url, const char* method, const char* upload_data,
     size_t* upload_data_size, std::ostream& body, int& error_code,
-    std::string& content_encoding, bool *redraw)
+    std::string& content_type, bool *redraw)
 {
     if (YDialog::topmostDialog(false))  {
         WidgetArray widgets;
@@ -55,5 +55,5 @@ void YHttpWidgetsHandler::process_request(struct MHD_Connection* connection,
         error_code = MHD_HTTP_NOT_FOUND;
     }
 
-    content_encoding = "application/json";
+    content_type = "application/json";
 }

--- a/src/YHttpWidgetsHandler.cc
+++ b/src/YHttpWidgetsHandler.cc
@@ -30,12 +30,14 @@ void YHttpWidgetsHandler::process_request(struct MHD_Connection* connection,
         WidgetArray widgets;
 
         // TODO: allow filtering by both label and type
-        if (const char* label = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "label"))
-            widgets = YWidgetFinder::by_label(label);
-        else if (const char* id = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "id"))
-            widgets = YWidgetFinder::by_id(id);
-        else if (const char* type = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "type"))
-            widgets = YWidgetFinder::by_type(type);
+        const char* label = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "label");
+        const char* id = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "id");
+        const char* type = MHD_lookup_connection_value(connection, MHD_GET_ARGUMENT_KIND, "type");
+
+        if ( label || id || type )
+        {
+            widgets = YWidgetFinder::find(label, id, type);
+        }
         else {
             widgets = YWidgetFinder::all();
         }

--- a/src/YHttpWidgetsHandler.h
+++ b/src/YHttpWidgetsHandler.h
@@ -32,7 +32,7 @@ protected:
     virtual void process_request(struct MHD_Connection* connection,
         const char* url, const char* method, const char* upload_data,
         size_t* upload_data_size, std::ostream& body, int& error_code,
-        std::string& content_encoding, bool *redraw);
+        std::string& content_type, bool *redraw);
 };
 
 #endif // YHttpWidgetsHandler_h

--- a/src/YJsonSerializer.cc
+++ b/src/YJsonSerializer.cc
@@ -16,6 +16,7 @@
 
 #include <json/json.h>
 
+#include "YBarGraph.h"
 #include "YButtonBox.h"
 #include "YComboBox.h"
 #include "YDialog.h"
@@ -408,5 +409,20 @@ static void serialize_widget_specific_data(YWidget *widget, Json::Value &json) {
         json["immediate_mode"] = tb->immediateMode();
         json["keep_sorting"] = tb->keepSorting();
         json["hasMultiSelection"] = tb->hasMultiSelection();
+    }
+
+    if ( auto bargraph = dynamic_cast<YBarGraph*>(widget) )
+    {
+        Json::Value jsegment, jsegments;
+        for ( auto idx = 0; idx < bargraph->segments(); ++idx )
+        {
+            std::string label;
+            YBarGraphSegment segment = bargraph->segment(idx);
+            jsegment["label"] = segment.label();
+            jsegment["value"] = segment.value();
+            jsegments.append(jsegment);
+        }
+        json["segments"] = jsegments;
+
     }
 }


### PR DESCRIPTION
For many widgets we have different behavior in qt and ncurses, so we
were adding activation methods to the libyui ncurses and qt libraries.
But as we already did the work to split libyui-rest-api in 3 packages,
we can override implementations for some widgets only.

Also, this PR makes json return format consistent, especially in case of error handling.

Some code duplication was removed by using templates as widgets are handled identically in many cases.

Dependent pull requests:
- [libyui](https://github.com/libyui/libyui/pull/166)
- [libyui-qt-rest-api](https://github.com/libyui/libyui-qt-rest-api/pull/4)
- [libyui-ncurses-rest-api](https://github.com/libyui/libyui-ncurses-rest-api/pull/3)