### PR TITLE
Use new libyui SO version 12

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "0")
 SET( VERSION_MINOR "4" )
-SET( VERSION_PATCH "0" )
+SET( VERSION_PATCH "1" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "11" )
+SET( SONAME_MAJOR "12" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-rest-api.changes
+++ b/package/libyui-rest-api.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:21:23 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new parent lib SO version libyui.so.12 (bsc#1172513)
+- 0.4.1 
+
+-------------------------------------------------------------------
 Wed Feb  5 12:09:35 UTC 2020 - Oleksandr Orlov <oorlov@suse.com>
 
 - Replace hard-coded HTML documentation with the url to the actual

--- a/package/libyui-rest-api.spec
+++ b/package/libyui-rest-api.spec
@@ -16,12 +16,12 @@
 #
 
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
-%define libyui_devel_version libyui-devel >= 3.8.0
+%define libyui_devel_version libyui-devel >= 3.10.0
 
 Name:           libyui-rest-api
-Version:        0.4.0
+Version:        0.4.1
 Release:        0
 Summary:        Libyui - REST API plugin, the shared part
 License:        LGPL-2.1-only OR LGPL-3.0-only


### PR DESCRIPTION
This is related to https://github.com/libyui/libyui/pull/165 :

The latest libyui needed to bump the SO version to 12 to maintain binary compatibility. The dependent packages like this need to adapt to that new version.
